### PR TITLE
Add vnc/ teaching material for GUI over VNC/noVNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ whoami: unknown uid 1000
 ## Devcontainer はどうやって UID/GID を変更しているのか？
 
 ユーザーの BASE_IMAGE から別のイメージを作成し、必要に応じてそこで書き換えているようです。devcontainers/cli の [updateUID.Dockerfile](https://github.com/devcontainers/cli/blob/d2c1bc89c39f79b8a8da437964976965f3400e81/scripts/updateUID.Dockerfile) を参照してください。
+
+## コンテナの中で GUI を動かして VNC で覗く
+
+headless なコンテナの中で GUI アプリを動かし、ホストの macOS から画面を VNC（あるいはブラウザの noVNC）で覗く最小教材です: [vnc](vnc)
+
+```console
+% cd vnc
+% docker image build -t vnc-image .
+% docker container run -it --rm --init -p 5901:5901 -p 6080:6080 --name vnc-container vnc-image
+% open vnc://localhost:5901          # ネイティブ VNC クライアント（画面共有）
+```
+
+ブラウザで見るなら `http://localhost:6080/vnc.html` を開きます（VNC クライアント不要）。詳細は [vnc/README.md](vnc/README.md) を参照してください。

--- a/vnc/Dockerfile
+++ b/vnc/Dockerfile
@@ -1,0 +1,34 @@
+# Debian 12 (bookworm) slim — git-ssh と同系列
+FROM debian:bookworm-slim
+
+# xvfb      : 画面のない仮想 X サーバ（メモリ上だけの framebuffer）
+# x11vnc    : その仮想画面を VNC プロトコルで配信する
+# x11-apps  : 動作確認用の xeyes を含む
+# fluxbox   : 軽量ウィンドウマネージャ（窓枠・移動・右クリックメニュー）
+# novnc     : ブラウザで動く VNC クライアント（Web ページ一式）
+# websockify: VNC(TCP) を WebSocket に変換して noVNC へ橋渡しする
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        xvfb x11vnc x11-apps fluxbox novnc websockify && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 非 root ユーザを「作成」する（user-test の学び: USER 指定だけでは作られない）。
+# 既定は 1000。ホストと UID/GID を合わせたいときは --build-arg で上書きする:
+#   docker build --build-arg user_id=$(id -u) --build-arg group_id=$(id -g) ...
+# GID が既存（macOS の staff=20 など）の場合は既存グループを流用する。
+ARG user_name=developer
+ARG user_id=1000
+ARG group_id=1000
+RUN if ! getent group "${group_id}" >/dev/null; then \
+        groupadd --gid "${group_id}" "${user_name}"; \
+    fi && \
+    useradd --uid "${user_id}" --gid "${group_id}" --create-home --shell /bin/bash "${user_name}"
+
+ENV HOME=/home/${user_name} DISPLAY=:1
+# 5901: x11vnc(VNC クライアント用) / 6080: noVNC(ブラウザ用)
+EXPOSE 5901 6080
+
+COPY --chmod=755 start-vnc.sh /usr/local/bin/start-vnc.sh
+
+USER ${user_name}
+CMD ["/usr/local/bin/start-vnc.sh"]

--- a/vnc/README.md
+++ b/vnc/README.md
@@ -1,0 +1,81 @@
+# コンテナの中で GUI を動かして VNC で覗く
+
+画面のない（headless な）コンテナの中で GUI アプリを動かし、ホストの macOS から
+その画面を VNC で覗くための最小教材です。参考実装
+
+## 仕組み
+
+Linux の GUI は **X11** で動きます。アプリ（クライアント）は「X サーバ」に描画を依頼し、
+X サーバが実際の画面へ描きます。コンテナには物理ディスプレイが無いので、代わりに
+**Xvfb**（X *virtual* framebuffer＝メモリ上だけの仮想画面）を X サーバとして立てます。
+その仮想画面を **x11vnc** が VNC で配信し、さらに **websockify + noVNC** が
+VNC を WebSocket に変換してブラウザからも見られるようにします。
+
+```text
+xeyes（GUI アプリ）
+   │ 描画を依頼
+   ▼
+Xvfb :1（仮想ディスプレイ）        ← 画面のない X サーバ
+   │ 画面を取得
+   ▼
+x11vnc ───────────────▶ :5901     ← ネイティブ VNC クライアント用
+   │ WebSocket に変換
+   ▼
+websockify + noVNC ───▶ :6080     ← ブラウザ用（クライアント不要）
+```
+
+**fluxbox** は軽量なウィンドウマネージャで、窓に枠を付けて移動・操作できるようにします。
+
+## ビルドと起動
+
+```console
+% cd vnc
+% docker image build -t vnc-image .
+% docker container run -it --rm --init -p 5901:5901 -p 6080:6080 --name vnc-container vnc-image
+```
+
+`--init` は cant_kill の教訓そのものです。1 つのコンテナで複数プロセス（Xvfb / fluxbox /
+x11vnc / websockify）を動かすため、PID 1 のシグナル転送とゾンビ回収を init（tini）に任せます。
+
+## 接続する（2 通り）
+
+### A. ネイティブ VNC クライアント（macOS の「画面共有」）
+
+```console
+% open vnc://localhost:5901
+```
+
+Finder の「サーバへ接続」（⌘K）に `vnc://localhost:5901` を入れても同じです。
+学習用途なのでパスワードは設定していません（後述）。
+
+### B. ブラウザ（noVNC）
+
+ブラウザで次の URL を開くだけです。VNC クライアントのインストールは不要です。
+
+```text
+http://localhost:6080/vnc.html
+```
+
+`Connect` を押すと、コンテナ内の画面（枠付きの xeyes と fluxbox のタスクバー）が表示されます。
+
+## ホストと UID/GID を合わせる
+
+`USER` を書くだけではユーザーは作られません（[user-test](../user-test) の学び）。
+本イメージは `developer` ユーザを実際に作成し、非 root で動かします。
+ホストと UID/GID を合わせたい場合（bind mount するときなどに効いてきます）は
+ビルド時に上書きします。
+
+```console
+% docker image build -t vnc-image \
+    --build-arg user_id=$(id -u) --build-arg group_id=$(id -g) .
+```
+
+macOS の既定 GID は `20`（staff）で、これは Debian の `dialout` と衝突しますが、
+Dockerfile 側で「その GID が既に在れば既存グループを流用する」ようにしてあるため
+そのままビルドできます。
+
+## セキュリティ（重要）
+
+このイメージは学習用の割り切りで、x11vnc を **パスワード無し（`-nopw`）** で起動しています。
+`-p` で公開したポートに誰でも繋げる状態なので、共有環境や公開ホストでは使わないでください。
+本番では `x11vnc -usepw`（パスワード）や SSH トンネル越しの接続にします。

--- a/vnc/start-vnc.sh
+++ b/vnc/start-vnc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eo pipefail
+
+# 1) 仮想ディスプレイ :1 を起動（1280x800・24bit カラー）
+Xvfb :1 -screen 0 1280x800x24 &
+
+# 2) X サーバのソケットが出来るまで待つ（追加パッケージ不要な簡易チェック）
+until [ -e /tmp/.X11-unix/X1 ]; do sleep 0.1; done
+
+# 3) ウィンドウマネージャ（窓枠・移動・右クリックメニュー）
+fluxbox &
+
+# 4) 動作確認用の GUI アプリ（目玉がカーソルを追う）。DISPLAY は ENV で :1
+xeyes &
+
+# 5) noVNC: VNC(5901) を WebSocket 経由でブラウザ(6080)へ橋渡し
+websockify --web=/usr/share/novnc 6080 localhost:5901 &
+
+# 6) 画面 :1 を VNC(5901) で配信。学習用途なのでパスワード無し(-nopw)
+exec x11vnc -display :1 -rfbport 5901 -forever -shared -nopw


### PR DESCRIPTION
## 概要

headless なコンテナの中で GUI アプリを動かし、ホストの macOS から VNC（あるいはブラウザの noVNC）で覗く最小教材 `vnc/` を追加します。

参考実装 [chromium-server-docker](https://github.com/uraitakahito/chromium-server-docker/blob/main/docker/development/Dockerfile) が `desktop-lite` feature で一括導入している VNC 一式を、各レイヤに分解して手で組み上げることで「なぜ映るのか」を理解できるようにしています。

## 構成

- `debian:bookworm-slim`（git-ssh と同系列）に **Xvfb / x11vnc / x11-apps / fluxbox / noVNC(websockify)**
- `start-vnc.sh`: `Xvfb :1` → `fluxbox` → `xeyes` → `websockify(6080)` → `x11vnc(5901)`
- 非 root ユーザ `developer` を作成（UID/GID は `--build-arg` で上書き可。macOS の GID=20 衝突もガード）
- ポート: **5901**（ネイティブ VNC クライアント）/ **6080**（ブラウザ noVNC）

## 既存テーマとの接続

- **cant_kill** … 複数プロセスの PID 1 対策として `--init`
- **user-test** … `USER` だけでは作られないユーザを実際に作成し UID/GID を合わせる
- **git-ssh** … `bookworm-slim` + 既存 `.hadolint.yaml`（DL3008）

## 動作確認

- ホスト `localhost:5901` が `RFB 003.008` を返答（VNC 到達性）
- noVNC `http://localhost:6080/vnc.html` が HTTP 200、`/websockify` が `101 Switching Protocols`
- 画面 `:1` のスクリーンショットで枠付き xeyes + fluxbox タスクバーを確認
- 非 root（`uid=1000`）で全機能動作、`hadolint` 指摘なし、ホスト UID/GID でのビルドも成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
